### PR TITLE
Add space to search bar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,7 +35,7 @@ const Navbar: FC = () => {
           >
             Shopify
           </Link>
-          <div className="lg:flex hidden w-full max-w-[500px]">
+          <div className="lg:flex hidden w-center max-w-[500px] border-1 border-blue-500 rounded overflow-hidden">
             <input
               type="text"
               placeholder="Search for a product..."


### PR DESCRIPTION
This change introduces a bit of extra space around the search bar to improve its layout and make it feel more balanced within the interface. It’s a small tweak aimed at enhancing usability without altering functionality.

<img width="589" height="134" alt="image" src="https://github.com/user-attachments/assets/e00106eb-2a6a-4b34-876b-76ca2174139e" />

Open to feedback if there’s a better way to handle this!